### PR TITLE
fix: update nuxt version constraint

### DIFF
--- a/modules/example/module.ts
+++ b/modules/example/module.ts
@@ -13,7 +13,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Compatibility constraints
     compatibility: {
         // Semver version of supported nuxt versions
-        nuxt: '^3.0.0'
+        nuxt: '^3.0.0-rc.1'
     }
   },
   defaults: {


### PR DESCRIPTION
In https://github.com/nuxt/framework/pull/7116 we made a breaking change allowing modules to use RC constraints. This PR fixes this.